### PR TITLE
Release 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Released]
 
+## [1.2.2] - 2021-08-23
+### Added
+- Added ability to manually add time tracking when no other time trackings have been added yet.
+### Fixed
+- Fixed issue with estimates since last release that caused estimates to not recognize the current user. The effect of this was that you could not delete estimates & couldn't see who made them. This is now resolves & you'll be able to view estimates with no user attached to it.
+
 ## [1.2.1] - 2021-06-17
 ### Added
 - Made it possible to view trackings from previous users on a board. They will now appear as N/A on a card under "Manage time" or "Time spent".

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "danniehansen/activity-timer",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "authors": [
         {
             "name": "Dannie Hansen",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activity_timer",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Trello power-up for tracking time spent on cards",
   "scripts": {
     "serve": "webpack serve --port 8080 --https --cert private.crt --key private.key --mode development --progress --open --hot",


### PR DESCRIPTION
## [1.2.2] - 2021-08-23
### Added
- Added ability to manually add time tracking when no other time trackings have been added yet.
### Fixed
- Fixed issue with estimates since last release that caused estimates to not recognize the current user. The effect of this was that you could not delete estimates & couldn't see who made them. This is now resolves & you'll be able to view estimates with no user attached to it.