### PR TITLE
Fix for estimate data exporter not always showing all cards

### DIFF
--- a/src/pages/DataExporter/TimeTracking/ApiCard.ts
+++ b/src/pages/DataExporter/TimeTracking/ApiCard.ts
@@ -52,7 +52,10 @@ export class ApiCard {
     const pluginData = data.pluginData.find((pluginData) => {
       return (
         pluginData.value &&
-        pluginData.value.includes('act-timer-ranges')
+        (
+          pluginData.value.includes('act-timer-ranges') ||
+          pluginData.value.includes('act-timer-estimates')
+        )
       );
     });
 


### PR DESCRIPTION
This PR fixes an issue where estimate data exporter did not show all cards. Found it was because it looked for active time trackings to locate plugin data. This has now been resolved to include plugin data that includes either active time trackings, and/or estimates.