### PR TITLE
Release 2.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Released]
 
-## [2.7.4] - 2024-03-11
+## [2.7.5] - 2024-03-12
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-. Removed Jest and associated code as there was no actual tests.
+- Removed Jest and associated code as there was no actual tests.
 
 ## [2.7.4] - 2024-01-28
 

--- a/src/capabilities/board-buttons/index.ts
+++ b/src/capabilities/board-buttons/index.ts
@@ -107,7 +107,7 @@ export async function getBoardButtons(): Promise<
         }
 
         items.push({
-          text: 'Version: 2.7.3'
+          text: 'Version: 2.7.5'
         });
 
         await t.popup({

--- a/src/capabilities/board-buttons/index.ts
+++ b/src/capabilities/board-buttons/index.ts
@@ -1,5 +1,5 @@
 import { Trello } from '../../types/trello';
-import ClockImageWhite from '../../assets/images/clock_white.svg';
+import ClockImageWhite from '../../assets/images/clock_white.svg?url';
 import { clearToken, getMemberId } from '../../components/trello';
 import { isVisible } from '../../utils/visibility';
 import { Card } from '../../components/card';

--- a/src/capabilities/board-buttons/index.ts
+++ b/src/capabilities/board-buttons/index.ts
@@ -1,5 +1,5 @@
 import { Trello } from '../../types/trello';
-import ClockImageWhite from '../../assets/images/clock_white.svg?url';
+import ClockImageWhite from '../../assets/images/clock_white.svg';
 import { clearToken, getMemberId } from '../../components/trello';
 import { isVisible } from '../../utils/visibility';
 import { Card } from '../../components/card';
@@ -16,8 +16,8 @@ export async function getBoardButtons(): Promise<
   return [
     {
       icon: {
-        light: `${window.location.origin}${ClockImageWhite}`,
-        dark: `${window.location.origin}${ClockImageWhite}`
+        light: ClockImageWhite,
+        dark: ClockImageWhite
       },
       text: 'Activity timer',
       callback: async (t) => {

--- a/src/capabilities/board-buttons/index.ts
+++ b/src/capabilities/board-buttons/index.ts
@@ -16,8 +16,12 @@ export async function getBoardButtons(): Promise<
   return [
     {
       icon: {
-        light: ClockImageWhite,
-        dark: ClockImageWhite
+        light: `${
+          !ClockImageWhite.includes('http') ? window.location.origin : ''
+        }${ClockImageWhite}`,
+        dark: `${
+          !ClockImageWhite.includes('http') ? window.location.origin : ''
+        }${ClockImageWhite}`
       },
       text: 'Activity timer',
       callback: async (t) => {

--- a/src/capabilities/card-back-section/index.ts
+++ b/src/capabilities/card-back-section/index.ts
@@ -1,5 +1,5 @@
 import { Trello } from '../../types/trello';
-import ClockImageBlack from '../../assets/images/clock_black.svg';
+import ClockImageBlack from '../../assets/images/clock_black.svg?url';
 
 export async function getCardBackSection(
   t: Trello.PowerUp.IFrame

--- a/src/capabilities/card-back-section/index.ts
+++ b/src/capabilities/card-back-section/index.ts
@@ -1,12 +1,12 @@
 import { Trello } from '../../types/trello';
-import ClockImageBlack from '../../assets/images/clock_black.svg?url';
+import ClockImageBlack from '../../assets/images/clock_black.svg';
 
 export async function getCardBackSection(
   t: Trello.PowerUp.IFrame
 ): Promise<Trello.PowerUp.CardBackSection> {
   return {
     title: 'Activity timer',
-    icon: `${window.location.origin}${ClockImageBlack}`,
+    icon: ClockImageBlack,
     content: {
       type: 'iframe',
       url: t.signUrl('./index.html', {

--- a/src/capabilities/card-back-section/index.ts
+++ b/src/capabilities/card-back-section/index.ts
@@ -6,7 +6,9 @@ export async function getCardBackSection(
 ): Promise<Trello.PowerUp.CardBackSection> {
   return {
     title: 'Activity timer',
-    icon: ClockImageBlack,
+    icon: `${
+      !ClockImageBlack.includes('http') ? window.location.origin : ''
+    }${ClockImageBlack}`,
     content: {
       type: 'iframe',
       url: t.signUrl('./index.html', {

--- a/src/capabilities/card-badges/index.ts
+++ b/src/capabilities/card-badges/index.ts
@@ -1,6 +1,6 @@
 import { Trello } from '../../types/trello';
-import EstimateImage from '../../assets/images/estimate.svg?url';
-import ClockImageBlack from '../../assets/images/clock_black.svg?url';
+import EstimateImage from '../../assets/images/estimate.svg';
+import ClockImageBlack from '../../assets/images/clock_black.svg';
 import { Card } from '../../components/card';
 import { formatTime } from '../../utils/formatting';
 import {
@@ -19,8 +19,8 @@ import {
 import { isVisible } from '../../utils/visibility';
 import { hasAutoTimer } from '../../utils/auto-timer';
 
-const clockIcon = `${window.location.origin}${ClockImageBlack}`;
-const estimateImage = `${window.location.origin}${EstimateImage}`;
+const clockIcon = ClockImageBlack;
+const estimateImage = EstimateImage;
 
 export async function getCardBadges(
   t: Trello.PowerUp.IFrame

--- a/src/capabilities/card-badges/index.ts
+++ b/src/capabilities/card-badges/index.ts
@@ -19,8 +19,12 @@ import {
 import { isVisible } from '../../utils/visibility';
 import { hasAutoTimer } from '../../utils/auto-timer';
 
-const clockIcon = ClockImageBlack;
-const estimateImage = EstimateImage;
+const clockIcon = `${
+  !ClockImageBlack.includes('http') ? window.location.origin : ''
+}${ClockImageBlack}`;
+const estimateImage = `${
+  !EstimateImage.includes('http') ? window.location.origin : ''
+}${EstimateImage}`;
 
 export async function getCardBadges(
   t: Trello.PowerUp.IFrame

--- a/src/capabilities/card-badges/index.ts
+++ b/src/capabilities/card-badges/index.ts
@@ -1,6 +1,6 @@
 import { Trello } from '../../types/trello';
-import EstimateImage from '../../assets/images/estimate.svg';
-import ClockImageBlack from '../../assets/images/clock_black.svg';
+import EstimateImage from '../../assets/images/estimate.svg?url';
+import ClockImageBlack from '../../assets/images/clock_black.svg?url';
 import { Card } from '../../components/card';
 import { formatTime } from '../../utils/formatting';
 import {

--- a/src/capabilities/card-buttons/index.ts
+++ b/src/capabilities/card-buttons/index.ts
@@ -6,7 +6,9 @@ import { settingsCallback } from './callbacks/Settings';
 import { timeSpentCallback } from './callbacks/TimeSpent';
 import { isVisible } from '../../utils/visibility';
 
-const icon = ClockImageBlack;
+const icon = `${
+  !ClockImageBlack.includes('http') ? window.location.origin : ''
+}${ClockImageBlack}`;
 
 export async function getCardButtons(): Promise<Trello.PowerUp.CardButton[]> {
   const visible = await isVisible();

--- a/src/capabilities/card-buttons/index.ts
+++ b/src/capabilities/card-buttons/index.ts
@@ -1,12 +1,12 @@
 import { Trello } from '../../types/trello';
-import ClockImageBlack from '../../assets/images/clock_black.svg?url';
+import ClockImageBlack from '../../assets/images/clock_black.svg';
 import { manageTimeCallback } from './callbacks/ManageTime';
 import { notificationsCallback } from './callbacks/Notifications';
 import { settingsCallback } from './callbacks/Settings';
 import { timeSpentCallback } from './callbacks/TimeSpent';
 import { isVisible } from '../../utils/visibility';
 
-const icon = `${window.location.origin}${ClockImageBlack}`;
+const icon = ClockImageBlack;
 
 export async function getCardButtons(): Promise<Trello.PowerUp.CardButton[]> {
   const visible = await isVisible();

--- a/src/capabilities/card-buttons/index.ts
+++ b/src/capabilities/card-buttons/index.ts
@@ -6,7 +6,7 @@ import { settingsCallback } from './callbacks/Settings';
 import { timeSpentCallback } from './callbacks/TimeSpent';
 import { isVisible } from '../../utils/visibility';
 
-const icon = `${window.location.origin}${ClockImageBlack}`;
+const icon = `${ClockImageBlack}`;
 
 export async function getCardButtons(): Promise<Trello.PowerUp.CardButton[]> {
   const visible = await isVisible();

--- a/src/capabilities/card-buttons/index.ts
+++ b/src/capabilities/card-buttons/index.ts
@@ -1,12 +1,12 @@
 import { Trello } from '../../types/trello';
-import ClockImageBlack from '../../assets/images/clock_black.svg';
+import ClockImageBlack from '../../assets/images/clock_black.svg?url';
 import { manageTimeCallback } from './callbacks/ManageTime';
 import { notificationsCallback } from './callbacks/Notifications';
 import { settingsCallback } from './callbacks/Settings';
 import { timeSpentCallback } from './callbacks/TimeSpent';
 import { isVisible } from '../../utils/visibility';
 
-const icon = `${ClockImageBlack}`;
+const icon = `${window.location.origin}${ClockImageBlack}`;
 
 export async function getCardButtons(): Promise<Trello.PowerUp.CardButton[]> {
   const visible = await isVisible();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   plugins: [vue(), mkcert()],
   server: { https: true },
   build: {
-    sourcemap: true
+    sourcemap: true,
+    assetsInlineLimit: 0
   }
 });


### PR DESCRIPTION
## [2.7.5] - 2024-03-12

### Security

- Updated packages to latest version matching version selectors.
- Updated node from 18 -> 20

### Fixed

- Fixed locale issues with estimation input not always accepting decimals. Now it's statically configured for en-GB locale.
- Fixed some cases of UI scroll when estimates, time spent and total estimate exceeded the visual limit.

### Removed

- Removed Jest and associated code as there was no actual tests.